### PR TITLE
refactor: add babel transform for export extensions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -24,6 +24,7 @@
   "plugins": [
     "tailcall-optimization",
     "transform-decorators-legacy",
+    "transform-export-extensions",
     "transform-flow-strip-types"
   ]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -14,7 +14,9 @@ all=warn
 
 [options]
 experimental.const_params=true
+
 esproposal.decorators=ignore
+esproposal.export_star_as=enable
 
 include_warnings=true
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel-plugin-tailcall-optimization": "1.0.11",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+    "babel-plugin-transform-export-extensions": "6.22.0",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "babel-preset-env": "1.6.0",
     "babel-preset-minify": "0.2.0",

--- a/packages/orio-core/src/index.js
+++ b/packages/orio-core/src/index.js
@@ -1,6 +1,4 @@
 // @flow
 
-import * as iter from 'orio-iter'
-
+export * as iter from 'orio-iter'
 export * from 'orio-stream'
-export { iter }

--- a/packages/orio-stream/src/index.js
+++ b/packages/orio-stream/src/index.js
@@ -1,6 +1,4 @@
 // @flow
 
-import * as sink from './sink'
-import * as stream from './stream'
-
-export { sink, stream }
+export * as sink from './sink'
+export * as stream from './stream'

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,6 +554,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-export-extensions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
+
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
@@ -756,6 +760,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
   dependencies:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-export-extensions@6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz#53738b47e75e8218589eea946cbbd39109bbe653"
+  dependencies:
+    babel-plugin-syntax-export-extensions "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-flow-strip-types@6.22.0:


### PR DESCRIPTION
[proposal-export-ns-from](/tc39/proposal-export-ns-from) makes for more ergonomic namespace exports.