### PR TITLE
chore(flow): remove unsafe getters and setters entry from .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -27,5 +27,3 @@ module.name_mapper='^orio-\(.*\)$' -> '<PROJECT_ROOT>/packages/orio-\1/src/index
 suppress_comment=\\(.\\|\n\\)*\\$ExpectError
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowIgnore
-
-unsafe.enable_getters_and_setters=true


### PR DESCRIPTION
This is no longer necessary.